### PR TITLE
trigger logging init earlier

### DIFF
--- a/src/main/java/io/reactivesocket/cli/Main.java
+++ b/src/main/java/io/reactivesocket/cli/Main.java
@@ -33,6 +33,7 @@ import io.reactivesocket.util.PayloadImpl;
 import io.reactivex.Flowable;
 import io.reactivex.netty.client.ClientState;
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Completable;
 import rx.Observable;
@@ -99,8 +100,12 @@ public class Main {
     public OutputHandler outputHandler;
     private TransportServer.StartedServer server;
 
+    private Logger retainedLogger;
+
     public void run() throws IOException, URISyntaxException, InterruptedException {
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", debug ? "debug" : "warn");
+
+        retainedLogger = LoggerFactory.getLogger("");
 
         InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
 


### PR DESCRIPTION
```
$ ./build/install/reactivesocket-cli/bin/reactivesocket-cli --server -i S --debug tcp://localhost:8765
[main] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
[main] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 24
[main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
[main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
[main] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
[main] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: available
[main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
[main] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): available
```