### PR TITLE
Use RxJava 2

### DIFF
--- a/src/main/java/io/reactivesocket/cli/Publishers.java
+++ b/src/main/java/io/reactivesocket/cli/Publishers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,18 +22,22 @@ import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
 import org.reactivestreams.Publisher;
 
-public final class ObservableIO {
+public final class Publishers {
 
-    private ObservableIO() {
+    private Publishers() {
         // No instances.
     }
 
     /**
-     * Return a publisher for consuming each line from System.in.
+     * Return a publisher for consuming each line from the passed stream.
      *
      * @param inputStream to read.
      */
     public static Publisher<Payload> lines(CharSource inputStream) {
-        return Flowable.just(inputStream).flatMapIterable(s -> s.readLines()).map(l -> (Payload) new PayloadImpl(l)).subscribeOn(Schedulers.io());
+        return Flowable.just(inputStream)
+                       .flatMapIterable(s -> s.readLines())
+                       .onBackpressureBuffer()
+                       .map(l -> (Payload) new PayloadImpl(l))
+                       .subscribeOn(Schedulers.io());
     }
 }

--- a/src/test/java/io/reactivesocket/cli/i9n/BasicOperationTest.java
+++ b/src/test/java/io/reactivesocket/cli/i9n/BasicOperationTest.java
@@ -37,7 +37,7 @@ public class BasicOperationTest {
     private TransportServer.StartedServer server;
     private ReactiveSocket client;
 
-    private TestOutputHandler expected = new TestOutputHandler();
+    private final TestOutputHandler expected = new TestOutputHandler();
 
     private ReactiveSocket requestHandler = new AbstractReactiveSocket() {
     };
@@ -46,6 +46,7 @@ public class BasicOperationTest {
 
     @Rule
     public TestRule watcher = new TestWatcher() {
+        @Override
         protected void starting(Description description) {
             testName = description.getMethodName();
         }
@@ -71,7 +72,7 @@ public class BasicOperationTest {
         }
         if (server != null) {
             server.shutdown();
-            server.awaitShutdown(5, TimeUnit.SECONDS);
+            server.awaitShutdown(5, SECONDS);
         }
     }
 
@@ -236,7 +237,7 @@ public class BasicOperationTest {
 
     private void run() throws Exception {
         connect();
-        main.run(client).await(5, SECONDS);
+        main.run(client).blockingAwait(5, SECONDS);
     }
 
     public static Payload reverse(String s) {


### PR DESCRIPTION
__Problem__

Current code bases uses RxJava 1 and reactive streams bridge. We can use RxJava 2 now as it is released.

__Modification__

Migrated all RxJava 1 uses to RxJava 2

__Result__

Cleaner code.