### PR TITLE
Output Out of Order

### DIFF
--- a/src/main/kotlin/io/rsocket/cli/Main.kt
+++ b/src/main/kotlin/io/rsocket/cli/Main.kt
@@ -234,7 +234,7 @@ class Main : HelpOption() {
       override fun requestChannel(payloads: Publisher<Payload>): Flux<Payload> {
         Flux.from(payloads).takeN(requestN)
           .onNext { outputHandler.showOutput(it.dataUtf8) }
-          .onError {outputHandler.showError("channel error", it) }.subscribe()
+          .onError { outputHandler.showError("channel error", it) }.subscribe()
         return inputPublisherX()
       }
 
@@ -295,7 +295,7 @@ class Main : HelpOption() {
     }
       .takeN(requestN)
       .map { it.dataUtf8 }
-      .onNext {outputHandler.showOutput(it) }
+      .onNext { outputHandler.showOutput(it) }
       .onError { outputHandler.showError("error from server", it) }
       .onErrorResume { Flux.empty() }
       .then().flux()

--- a/src/main/kotlin/io/rsocket/cli/util.kt
+++ b/src/main/kotlin/io/rsocket/cli/util.kt
@@ -185,7 +185,7 @@ fun <T> Flux<T>.takeN(request: Int): Flux<T> =
   if (request < Int.MAX_VALUE) this.limitRate(request).take(request.toLong()) else this
 
 fun <T> Flux<T>.onNext(block: suspend (T) -> Unit): Flux<T> {
-  return this.flatMap {
+  return this.concatMap {
     mono {
       block.invoke(it)
     }.thenMany(Flux.just(it))


### PR DESCRIPTION
Previously, when output was printed it was output inside of a `.flatMap()` invocation.  Because flatMap can be parallelized and handled out of order, there was no guarantee that the output would be printed in the order it was received.  This change updates that call to print the output in `.concatMap()` which guarantees a consistent ordering.