### PR TITLE
Add sanitization of uri to ensure a ws/wss uri is not malformed when passed as arg

### DIFF
--- a/src/main/kotlin/io/rsocket/cli/Main.kt
+++ b/src/main/kotlin/io/rsocket/cli/Main.kt
@@ -48,6 +48,7 @@ import org.reactivestreams.Publisher
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.ArrayList
 import java.util.concurrent.TimeUnit
@@ -145,7 +146,7 @@ class Main {
     }
 
     try {
-      val uri = arguments[0]
+      val uri = sanitizeUri(arguments[0])
 
       if (serverMode) {
         server = buildServer(uri)
@@ -229,6 +230,16 @@ class Main {
     // TODO chain
     runAllOperations(socket).subscribe()
     return Mono.just(createResponder(socket))
+  }
+  
+  private fun sanitizeUri(uri: String): String {
+    var validationUri = URI(uri)
+    if (validationUri.scheme == "ws" || validationUri.scheme == "wss") {
+      if (validationUri.path.isEmpty()) {
+        return "$uri/"
+      }
+    }
+    return uri
   }
 
   fun createResponder(socket: RSocket): AbstractRSocket {


### PR DESCRIPTION
This PR fixes https://github.com/rsocket/rsocket-cli/issues/67

This makes the cli interface consistent with the usage for different protocols. While `tcp://localhost:8765` would work `ws://localhost:8080` would not work currently as the UriEndpointFactory in netty throws when / is not appended at the end. (A valid url would be `ws://localhost:8080/`)

This PR addresses this by intercepting the URI before it is passed to the client builder, and modifying the URI if the Path is empty and the scheme equals wss or ws.